### PR TITLE
fix: hard-coding credentials

### DIFF
--- a/create_tables.py
+++ b/create_tables.py
@@ -1,29 +1,38 @@
+# -- coding: utf-8 --
+"""This script create the Sparkify database and all its tables. """
 import psycopg2
 from sql_queries import create_table_queries, drop_table_queries
+import argparse
 
 
-def create_database():
+def create_database(user_name: str, password: str):
     """
     - Creates and connects to the sparkifydb
     - Returns the connection and cursor to sparkifydb
     """
     
     # connect to default database
-    conn = psycopg2.connect("host=127.0.0.1 dbname=studentdb user=student password=student")
+    conn = psycopg2.connect(
+        f"host=127.0.0.1 dbname=postgres user={user_name} password={password}"
+    )
     conn.set_session(autocommit=True)
     cur = conn.cursor()
     
     # create sparkify database with UTF8 encoding
     cur.execute("DROP DATABASE IF EXISTS sparkifydb")
-    cur.execute("CREATE DATABASE sparkifydb WITH ENCODING 'utf8' TEMPLATE template0")
+    cur.execute("CREATE DATABASE sparkifydb WITH ENCODING 'utf8' "
+                "TEMPLATE template0")
 
     # close connection to default database
-    conn.close()    
-    
+    conn.close()
+
     # connect to sparkify database
-    conn = psycopg2.connect("host=127.0.0.1 dbname=sparkifydb user=student password=student")
+    conn = psycopg2.connect(
+        f"host=127.0.0.1 dbname=sparkifydb user={user_name} "
+        f"password={password}"
+    )
     cur = conn.cursor()
-    
+
     return cur, conn
 
 
@@ -45,7 +54,7 @@ def create_tables(cur, conn):
         conn.commit()
 
 
-def main():
+def main(user_name: str, password: str):
     """
     - Drops (if exists) and Creates the sparkify database. 
     
@@ -58,7 +67,7 @@ def main():
     
     - Finally, closes the connection. 
     """
-    cur, conn = create_database()
+    cur, conn = create_database(user_name, password)
     
     drop_tables(cur, conn)
     create_tables(cur, conn)
@@ -67,4 +76,26 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+
+    parser = argparse.ArgumentParser(
+        description='Users and Passwords',
+    )
+
+    parser.add_argument(
+        '-u', '--user_name',
+        type=str,
+        help='Postgres Database user name',
+        required=True,
+    )
+
+    parser.add_argument(
+        '-p', '--password',
+        type=str,
+        help='Postgres Database password',
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    main(args.user_name, args.password)
+

--- a/create_tables.py
+++ b/create_tables.py
@@ -1,30 +1,39 @@
 # -- coding: utf-8 --
 """This script create the Sparkify database and all its tables. """
+from typing import Tuple
 import psycopg2
 from sql_queries import create_table_queries, drop_table_queries
 import argparse
+from psycopg2.extensions import cursor as Cursor
+from psycopg2.extensions import connection as Connection
 
 
-def create_database(user_name: str, password: str):
+def create_database(
+        user_name: str,
+        password: str
+) -> Tuple[Cursor, Connection]:
     """
     - Creates and connects to the sparkifydb
     - Returns the connection and cursor to sparkifydb
     """
     
     # connect to default database
-    conn = psycopg2.connect(
-        f"host=127.0.0.1 dbname=postgres user={user_name} password={password}"
-    )
-    conn.set_session(autocommit=True)
-    cur = conn.cursor()
-    
-    # create sparkify database with UTF8 encoding
-    cur.execute("DROP DATABASE IF EXISTS sparkifydb")
-    cur.execute("CREATE DATABASE sparkifydb WITH ENCODING 'utf8' "
-                "TEMPLATE template0")
+    try:
+        conn = psycopg2.connect(
+            f"host=127.0.0.1 dbname=postgres user={user_name} "
+            f"password={password}")
 
-    # close connection to default database
-    conn.close()
+        conn.set_session(autocommit=True)
+
+        with conn.cursor() as cur:
+            cur.execute("DROP DATABASE IF EXISTS sparkifydb")
+            cur.execute("CREATE DATABASE sparkifydb WITH ENCODING 'utf8' "
+                        "TEMPLATE template0"
+                        )
+    finally:
+        if conn:
+            conn.close()
+
 
     # connect to sparkify database
     conn = psycopg2.connect(
@@ -98,4 +107,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     main(args.user_name, args.password)
+
 


### PR DESCRIPTION
In order to avoid hard-coding user_name and password when connecting to the database when creating sparkifydb database and tables, I have refactored the create_database function and added argsparse to the main call.